### PR TITLE
fix: Image source and URL in .goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -59,8 +59,8 @@ dockers:
       - --platform=linux/amd64
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description=Unbound DNS webhook for external-dns
-      - --label=org.opencontainers.image.url=https://{{ .Env.GITHUB_SERVER_URL }}/{{ .Env.GITHUB_REPOSITORY }}
-      - --label=org.opencontainers.image.source=https://{{ .Env.GITHUB_SERVER_URL }}/{{ .Env.GITHUB_REPOSITORY }}
+      - --label=org.opencontainers.image.url={{ .Env.GITHUB_SERVER_URL }}/{{ .Env.GITHUB_REPOSITORY }}
+      - --label=org.opencontainers.image.source={{ .Env.GITHUB_SERVER_URL }}/{{ .Env.GITHUB_REPOSITORY }}
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}


### PR DESCRIPTION
GITHUB_SERVER_URL already includes protocol.

Before the fix:
```json
{
    "labels": {
        "org.opencontainers.image.source": "https://https://github.com/guillomep/external-dns-unbound-webhook",
        "org.opencontainers.image.url": "https://https://github.com/guillomep/external-dns-unbound-webhook"
    }
}
```