### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/guillomep/external-dns-unbound-webhook/security/code-scanning/1](https://github.com/guillomep/external-dns-unbound-webhook/security/code-scanning/1)

The best way to fix this problem is to explicitly specify a `permissions` block at the highest appropriate level in the workflow YAML. For most CI workflows, the minimum required is `contents: read`, which allows steps to check out the code repository but not to write to it. Since the workflow contains no steps that explicitly require write access (e.g., creating releases, pushing code, modifying issues or PRs), setting `contents: read` at the workflow or job level suffices. Ideally, you should add the following block at the root level (right below `name: CI`), ensuring all jobs default to these minimal permissions. If in future there are jobs needing write permissions, those jobs can be given additional permissions individually.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
